### PR TITLE
test: mock OpenBB helper API calls

### DIFF
--- a/tests/unittests/core/test_openbb_helpers.py
+++ b/tests/unittests/core/test_openbb_helpers.py
@@ -1,35 +1,112 @@
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock
 
 import polars as pl
 import pytest
-from openbb_core.app.model.abstract.error import OpenBBError
 
-from humbldata.core.utils.openbb_helpers import get_latest_price, obb_login
-
-pytestmark = pytest.mark.skip(reason="Need to figure out OBB Login")
-
-# skip_if_not_logged_in = pytest.mark.skipif(
-#     not obb_login(), reason="Login failed"
-# )
-
-# Need to find a way to test making web requests without actually making them,
-# potentially mock the obb function call
-
-
-# @skip_if_not_logged_in
-# @pytest.mark.skip()
-@pytest.mark.parametrize(
-    "symbol",
-    ["AAPL", ["AAPL", "GOOGL"]],
+from humbldata.core.standard_models.abstract.humblobject import HumblObject
+from humbldata.core.utils.openbb_helpers import (
+    aget_equity_sector,
+    aget_etf_category,
+    aget_latest_price,
+    obb_login,
 )
-def test_get_latest_price(symbol):
-    """Test the get_recent_price function."""
-    prices = get_latest_price(symbol, "fmp")
-    assert isinstance(prices, pl.LazyFrame)
 
 
-@pytest.mark.skip()
-def test_get_latest_price_with_invalid_symbol():
-    """Test that get_recent_price raises a ValueError when an invalid symbol is passed."""
-    with pytest.raises(OpenBBError):
-        get_latest_price("")
+def api_response(data: dict[str, list[object]]) -> HumblObject[pl.LazyFrame]:
+    return HumblObject(results=pl.LazyFrame(data))
+
+
+def test_aget_latest_price_mocks_equity_price_quote(monkeypatch):
+    fetch_data = AsyncMock(
+        return_value=api_response(
+            {
+                "symbol": ["AAPL", "XLE"],
+                "asset_type": ["EQUITY", "ETF"],
+                "last_price": [190.0, None],
+                "prev_close": [188.0, 88.0],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "humbldata.core.utils.openbb_helpers.OpenBBAPIClient.fetch_data",
+        fetch_data,
+    )
+
+    result = asyncio.run(
+        aget_latest_price(pl.Series("symbol", ["AAPL", "XLE"]))
+    )
+
+    assert result.collect().to_dict(as_series=False) == {
+        "last_price": [190.0, 88.0],
+        "symbol": ["AAPL", "XLE"],
+    }
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "equity.price.quote"
+    assert kwargs["api_query_params"].symbol == ["AAPL", "XLE"]
+    assert kwargs["api_query_params"].provider == "yfinance"
+
+
+def test_aget_equity_sector_mocks_equity_profile(monkeypatch):
+    fetch_data = AsyncMock(
+        return_value=api_response(
+            {
+                "symbol": ["AAPL", "NVDA"],
+                "sector": ["Technology", "Technology"],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "humbldata.core.utils.openbb_helpers.OpenBBAPIClient.fetch_data",
+        fetch_data,
+    )
+
+    result = asyncio.run(aget_equity_sector(["AAPL", "NVDA"], provider="fmp"))
+
+    assert result.collect().to_dict(as_series=False) == {
+        "symbol": ["AAPL", "NVDA"],
+        "sector": ["Technology", "Technology"],
+    }
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "equity.profile"
+    assert kwargs["api_query_params"].symbol == ["AAPL", "NVDA"]
+    assert kwargs["api_query_params"].provider == "fmp"
+
+
+def test_aget_etf_category_mocks_etf_info(monkeypatch):
+    fetch_data = AsyncMock(
+        return_value=api_response(
+            {
+                "symbol": ["XLE"],
+                "category": ["Equity Energy"],
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "humbldata.core.utils.openbb_helpers.OpenBBAPIClient.fetch_data",
+        fetch_data,
+    )
+
+    result = asyncio.run(
+        aget_etf_category(["AAPL", "XLE"], provider="yfinance")
+    )
+
+    assert result.collect().to_dict(as_series=False) == {
+        "symbol": ["AAPL", "XLE"],
+        "category": [None, "Equity Energy"],
+    }
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "etf.info"
+    assert kwargs["api_query_params"].symbol == ["XLE"]
+    assert kwargs["api_query_params"].provider == "yfinance"
+
+
+def test_obb_login_returns_false_and_warns():
+    with pytest.warns(
+        Warning,
+        match="obb_login is deprecated",
+    ):
+        assert obb_login("unused-token") is False


### PR DESCRIPTION
## Summary
- replace the skipped OpenBB helper test module with mocked async API-client coverage
- cover latest price, equity sector, ETF category, and deprecated login behavior
- assert each helper calls the expected OpenBB API path and provider parameters

Closes #38

## Test
- uv run pytest tests/unittests/core/test_openbb_helpers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation coverage for async data helper functions including price quotes, sector lookups, and ETF category retrieval.
  
* **Chores**
  * Deprecated legacy authentication method with associated warning notification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/humblFINANCE/humblDATA/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->