### PR TITLE
Fix historical humbl channel nulls for misaligned symbols

### DIFF
--- a/src/humbldata/toolbox/technical/humbl_channel/model.py
+++ b/src/humbldata/toolbox/technical/humbl_channel/model.py
@@ -198,7 +198,7 @@ def calc_humbl_channel(  # noqa: PLR0913
     return out
 
 
-def _calc_humbl_for_date(
+def _calc_humbl_for_date(  # noqa: PLR0913
     date,
     data,
     window,
@@ -208,11 +208,16 @@ def _calc_humbl_for_date(
     rv_grouped_mean,
     yesterday_close,
     use_live_price=None,
+    active_symbols=None,
     **kwargs,
 ):
     """Calculate Mandelbrot Channel for a single date."""
     # Only include data up to the target date, this prevents look-ahead bias
     filtered_data = data.filter(pl.col("date") <= date)
+    if active_symbols is not None:
+        filtered_data = filtered_data.filter(
+            pl.col("symbol").is_in(active_symbols)
+        )
 
     return calc_humbl_channel(
         data=filtered_data,
@@ -224,6 +229,87 @@ def _calc_humbl_for_date(
         yesterday_close=yesterday_close,
         **kwargs,
     )
+
+
+def _raise_historical_window_error(start_date, end_date) -> None:
+    msg = (
+        "You set <historical=True> \n"
+        "        This calculation needs *at least* one window of data. \n"
+        f"        The (start date + window) is: {start_date} "
+        f"and the dataset ended: {end_date}. \n"
+        "        Please adjust dates accordingly."
+    )
+    raise HumblDataError(msg)
+
+
+def _historical_date_groups(
+    data: pl.DataFrame | pl.LazyFrame, window_days
+) -> tuple[pl.LazyFrame, list[tuple[object, tuple[str, ...] | None]]]:
+    """Return dates with symbols that have enough history on each date."""
+    data = data.lazy()
+    schema = data.collect_schema().names()
+
+    if "symbol" not in schema:
+        start_date = data.select(pl.col("date")).min().collect().row(0)[0]
+        start_date = start_date + window_days
+        end_date = data.select("date").max().collect().row(0)[0]
+
+        if start_date >= end_date:
+            _raise_historical_window_error(start_date, end_date)
+
+        dates = (
+            data.select(pl.col("date"))
+            .filter(pl.col("date") >= start_date)
+            .unique()
+            .sort("date")
+            .collect()
+            .to_series()
+        )
+        return data, [(date, None) for date in dates]
+
+    symbol_ranges = (
+        data.group_by("symbol")
+        .agg(
+            pl.col("date").min().alias("start_date"),
+            pl.col("date").max().alias("end_date"),
+        )
+        .collect()
+    )
+    symbol_start_dates = symbol_ranges.with_columns(
+        (pl.col("start_date") + window_days).alias("calculation_start_date")
+    ).filter(pl.col("calculation_start_date") < pl.col("end_date"))
+
+    date_symbols = (
+        data.select("date", "symbol")
+        .join(
+            symbol_start_dates.select(
+                "symbol", "calculation_start_date"
+            ).lazy(),
+            on="symbol",
+            how="inner",
+        )
+        .filter(pl.col("date") >= pl.col("calculation_start_date"))
+        .group_by("date")
+        .agg(pl.col("symbol").unique().alias("active_symbols"))
+        .sort("date")
+        .collect()
+    )
+
+    if date_symbols.is_empty():
+        start_date = symbol_ranges["start_date"].min() + window_days
+        end_date = symbol_ranges["end_date"].max()
+        _raise_historical_window_error(start_date, end_date)
+
+    date_groups = [
+        (date, tuple(active_symbols))
+        for date, active_symbols in date_symbols.iter_rows()
+    ]
+
+    return data, date_groups
+
+
+def _run_historical_calc(calc_func, date, active_symbols):
+    return calc_func(date, active_symbols=active_symbols)
 
 
 def calc_humbl_channel_historical_concurrent(
@@ -253,28 +339,8 @@ def calc_humbl_channel_historical_concurrent(
     Other parameters are the same as calc_humbl_channel_historical.
     """
     window_days = _window_format(window, _return_timedelta=True)
-    start_date = data.lazy().select(pl.col("date")).min().collect().row(0)[0]
-    start_date = start_date + window_days
-    end_date = data.lazy().select("date").max().collect().row(0)[0]
+    data, date_groups = _historical_date_groups(data, window_days)
 
-    if start_date >= end_date:
-        msg = f"You set <historical=True> \n\
-        This calculation needs *at least* one window of data. \n\
-        The (start date + window) is: {start_date} and the dataset ended: {end_date}. \n\
-        Please adjust dates accordingly."
-        raise HumblDataError(msg)
-
-    dates = (
-        data.lazy()
-        .select(pl.col("date"))
-        .filter(pl.col("date") >= start_date)
-        .unique()
-        .sort("date")
-        .collect()
-        .to_series()
-    )
-
-    # Prepare the partial function with all arguments except the date
     calc_func = partial(
         _calc_humbl_for_date,
         data=data,
@@ -295,7 +361,10 @@ def calc_humbl_channel_historical_concurrent(
     )
     # Use concurrent.futures to calculate in parallel
     with executor_class(max_workers=max_workers) as executor:
-        futures = [executor.submit(calc_func, date) for date in dates]
+        futures = [
+            executor.submit(calc_func, date, active_symbols=active_symbols)
+            for date, active_symbols in date_groups
+        ]
         results = [
             future.result()
             for future in concurrent.futures.as_completed(futures)
@@ -304,7 +373,7 @@ def calc_humbl_channel_historical_concurrent(
     # Combine results
     out = pl.concat(results, how="vertical").sort(["symbol", "date"])
 
-    return out.lazy()
+    return out.lazy() if isinstance(out, pl.DataFrame) else out
 
 
 async def acalc_humbl_channel(  # noqa: PLR0913
@@ -360,31 +429,19 @@ async def _acalc_humbl_channel_historical_engine(  # noqa: PLR0913
     `calc_humbl_channel_historical()`.
     """
     window_days = _window_format(window, _return_timedelta=True)
-    start_date = data.lazy().select(pl.col("date")).min().collect().row(0)[0]
-    start_date = start_date + window_days
-    end_date = data.lazy().select("date").max().collect().row(0)[0]
-
-    if start_date >= end_date:
-        msg = f"You set <historical=True> \n\
-        This calculation needs *at least* one window of data. \n\
-        The (start date + window) is: {start_date} and the dataset ended: {end_date}. \n\
-        Please adjust dates accordingly."
-        raise HumblDataError(msg)
-
-    dates = (
-        data.lazy()
-        .select(pl.col("date"))
-        .filter(pl.col("date") >= start_date)
-        .unique()
-        .sort("date")
-        .collect()
-        .to_series()
-    )
+    data, date_groups = _historical_date_groups(data, window_days)
 
     tasks = [
         asyncio.create_task(
             acalc_humbl_channel(
-                data=data.filter(pl.col("date") <= date),
+                data=(
+                    data.filter(pl.col("date") <= date)
+                    if active_symbols is None
+                    else data.filter(
+                        (pl.col("date") <= date)
+                        & pl.col("symbol").is_in(active_symbols)
+                    )
+                ),
                 window=window,
                 rv_adjustment=rv_adjustment,
                 rv_method=rv_method,
@@ -394,7 +451,7 @@ async def _acalc_humbl_channel_historical_engine(  # noqa: PLR0913
                 **kwargs,
             )
         )
-        for date in dates
+        for date, active_symbols in date_groups
     ]
 
     lazyframes = await asyncio.gather(*tasks)
@@ -476,28 +533,8 @@ def calc_humbl_channel_historical_mp(
     Other parameters are the same as calc_humbl_channel_historical.
     """
     window_days = _window_format(window, _return_timedelta=True)
-    start_date = data.lazy().select(pl.col("date")).min().collect().row(0)[0]
-    start_date = start_date + window_days
-    end_date = data.lazy().select("date").max().collect().row(0)[0]
+    data, date_groups = _historical_date_groups(data, window_days)
 
-    if start_date >= end_date:
-        msg = f"You set <historical=True> \n\
-        This calculation needs *at least* one window of data. \n\
-        The (start date + window) is: {start_date} and the dataset ended: {end_date}. \n\
-        Please adjust dates accordingly."
-        raise HumblDataError(msg)
-
-    dates = (
-        data.lazy()
-        .select(pl.col("date"))
-        .filter(pl.col("date") >= start_date)
-        .unique()
-        .sort("date")
-        .collect()
-        .to_series()
-    )
-
-    # Prepare the partial function with all arguments except the date
     calc_func = partial(
         _calc_humbl_for_date,
         data=data,
@@ -512,9 +549,13 @@ def calc_humbl_channel_historical_mp(
 
     # Use multiprocessing to calculate in parallel
     with multiprocessing.Pool(processes=n_processes) as pool:
-        results = pool.map(calc_func, dates)
+        calc_args = [
+            (calc_func, date, active_symbols)
+            for date, active_symbols in date_groups
+        ]
+        results = pool.starmap(_run_historical_calc, calc_args)
 
     # Combine results
     out = pl.concat(results, how="vertical").sort(["symbol", "date"])
 
-    return out.lazy()
+    return out.lazy() if isinstance(out, pl.DataFrame) else out

--- a/src/humbldata/toolbox/technical/humbl_channel/model.py
+++ b/src/humbldata/toolbox/technical/humbl_channel/model.py
@@ -212,12 +212,7 @@ def _calc_humbl_for_date(  # noqa: PLR0913
     **kwargs,
 ):
     """Calculate Mandelbrot Channel for a single date."""
-    # Only include data up to the target date, this prevents look-ahead bias
-    filtered_data = data.filter(pl.col("date") <= date)
-    if active_symbols is not None:
-        filtered_data = filtered_data.filter(
-            pl.col("symbol").is_in(active_symbols)
-        )
+    filtered_data = _filter_for_date_and_symbols(data, date, active_symbols)
 
     return calc_humbl_channel(
         data=filtered_data,
@@ -231,7 +226,20 @@ def _calc_humbl_for_date(  # noqa: PLR0913
     )
 
 
+def _filter_for_date_and_symbols(data, date, active_symbols=None):
+    """Filter historical rows to a target date and optional active symbols."""
+    # Only include data up to the target date, this prevents look-ahead bias
+    filtered_data = data.filter(pl.col("date") <= date)
+    if active_symbols is not None:
+        filtered_data = filtered_data.filter(
+            pl.col("symbol").is_in(active_symbols)
+        )
+
+    return filtered_data
+
+
 def _raise_historical_window_error(start_date, end_date) -> None:
+    """Raise a consistent error when no historical date can be calculated."""
     msg = (
         "You set <historical=True> \n"
         "        This calculation needs *at least* one window of data. \n"
@@ -309,6 +317,7 @@ def _historical_date_groups(
 
 
 def _run_historical_calc(calc_func, date, active_symbols):
+    """Run a picklable historical calculation for multiprocessing workers."""
     return calc_func(date, active_symbols=active_symbols)
 
 
@@ -328,8 +337,8 @@ def calc_humbl_channel_historical_concurrent(
     """
     Calculate the Humbl Channel historically using concurrent.futures.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     max_workers : int, optional
         Maximum number of workers to use. If None, it uses the default for ProcessPoolExecutor
         or ThreadPoolExecutor (usually the number of processors on the machine, multiplied by 5).
@@ -434,14 +443,7 @@ async def _acalc_humbl_channel_historical_engine(  # noqa: PLR0913
     tasks = [
         asyncio.create_task(
             acalc_humbl_channel(
-                data=(
-                    data.filter(pl.col("date") <= date)
-                    if active_symbols is None
-                    else data.filter(
-                        (pl.col("date") <= date)
-                        & pl.col("symbol").is_in(active_symbols)
-                    )
-                ),
+                data=_filter_for_date_and_symbols(data, date, active_symbols),
                 window=window,
                 rv_adjustment=rv_adjustment,
                 rv_method=rv_method,
@@ -461,8 +463,6 @@ async def _acalc_humbl_channel_historical_engine(  # noqa: PLR0913
         .rename({"recent_price": "close_price"})
         .collect_async()
     )
-
-    # out = await pl.collect_all_async(lazyframes)
 
     return out.lazy()
 
@@ -525,8 +525,8 @@ def calc_humbl_channel_historical_mp(
     """
     Calculate the Humbl Channel historically using multiprocessing.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     n_processes : int, optional
         Number of processes to use. If None, it uses all available cores.
 

--- a/tests/integration/toolbox/technical/mandelbrot_channel/test_model.py
+++ b/tests/integration/toolbox/technical/mandelbrot_channel/test_model.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import polars as pl
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -33,6 +35,70 @@ def equity_historical(request: FixtureRequest):
     elif request.param == "lazyframe_multiple_symbols":
         return pl.LazyFrame(data)
     return None
+
+
+def _synthetic_equity_rows(
+    symbol: str, start: dt.date, rows: int, base_price: float
+) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "date": pl.date_range(
+                start=start,
+                end=start + dt.timedelta(days=rows - 1),
+                interval="1d",
+                eager=True,
+            ),
+            "symbol": [symbol] * rows,
+            "open": [base_price + (idx * 0.1) for idx in range(rows)],
+            "high": [base_price + (idx * 0.1) + 0.5 for idx in range(rows)],
+            "low": [base_price + (idx * 0.1) - 0.5 for idx in range(rows)],
+            "close": [base_price + (idx * 0.1) for idx in range(rows)],
+            "volume": [1000 + idx for idx in range(rows)],
+        }
+    )
+
+
+@pytest.mark.integration
+def test_humbl_channel_historical_uses_each_symbols_own_start_date():
+    """Mixed symbols should match each symbol calculated independently."""
+    equity_data = pl.concat(
+        [
+            _synthetic_equity_rows("AAPL", dt.date(2020, 1, 1), 90, 100),
+            _synthetic_equity_rows("PCT", dt.date(2020, 2, 15), 50, 10),
+        ]
+    )
+
+    pct_only = calc_humbl_channel_historical(
+        equity_data.filter(pl.col("symbol") == "PCT"),
+        window="1m",
+        rv_adjustment=True,
+        rv_method="std",
+        rv_grouped_mean=False,
+        rs_method="RS",
+    ).collect()
+    combined = calc_humbl_channel_historical(
+        equity_data,
+        window="1m",
+        rv_adjustment=True,
+        rv_method="std",
+        rv_grouped_mean=False,
+        rs_method="RS",
+    ).collect()
+    combined_pct = combined.filter(pl.col("symbol") == "PCT")
+    price_cols = ["bottom_price", "close_price", "top_price"]
+
+    assert combined_pct.equals(pct_only)
+    assert (
+        combined.select(
+            pl.any_horizontal(
+                *[
+                    pl.col(col).is_null() | pl.col(col).is_nan()
+                    for col in price_cols
+                ]
+            ).sum()
+        ).item()
+        == 0
+    )
 
 
 @pytest.mark.integration()

--- a/tests/integration/toolbox/technical/mandelbrot_channel/test_model.py
+++ b/tests/integration/toolbox/technical/mandelbrot_channel/test_model.py
@@ -1,3 +1,5 @@
+"""Integration tests for Humbl Channel model calculations."""
+
 import datetime as dt
 
 import polars as pl
@@ -27,12 +29,12 @@ def equity_historical(request: FixtureRequest):
     if request.param == "dataframe_single_symbol":
         data = data.filter(pl.col("symbol") == "AAPL")
         return data
-    elif request.param == "lazyframe_single_symbol":
+    if request.param == "lazyframe_single_symbol":
         data = data.filter(pl.col("symbol") == "AAPL")
         return pl.LazyFrame(data)
-    elif request.param == "dataframe_multiple_symbols":
+    if request.param == "dataframe_multiple_symbols":
         return data
-    elif request.param == "lazyframe_multiple_symbols":
+    if request.param == "lazyframe_multiple_symbols":
         return pl.LazyFrame(data)
     return None
 
@@ -101,7 +103,7 @@ def test_humbl_channel_historical_uses_each_symbols_own_start_date():
     )
 
 
-@pytest.mark.integration()
+@pytest.mark.integration
 def test_humbl_channel_integration(equity_historical, request: FixtureRequest):
     """Testing the composed function of `calc_humbl_channel()`."""
     current_param = request.node.callspec.params.get("equity_historical")
@@ -157,7 +159,7 @@ def test_humbl_channel_integration(equity_historical, request: FixtureRequest):
     ]
 
 
-@pytest.mark.integration()
+@pytest.mark.integration
 def test_humbl_channel_historical_integration(
     equity_historical, request: FixtureRequest
 ):
@@ -183,8 +185,8 @@ def test_humbl_channel_historical_integration(
         )
         expected_aapl_top_and_bottom = (
             "AAPL",
-            pytest.approx(32.17, rel=1e-3),
-            pytest.approx(36.96, rel=1e-3),
+            pytest.approx(33.36, rel=1e-3),
+            pytest.approx(35.68, rel=1e-3),
         )
         pct_top_and_bottom_mean = (
             mandelbrot_historical.group_by("symbol")
@@ -193,8 +195,8 @@ def test_humbl_channel_historical_integration(
         )
         expected_pct_top_and_bottom = (
             "PCT",
-            pytest.approx(9.55, rel=1e-3),
-            pytest.approx(12.00, rel=1e-3),
+            pytest.approx(9.44, rel=1e-3),
+            pytest.approx(12.27, rel=1e-3),
         )
         google_top_and_bottom_mean = (
             mandelbrot_historical.group_by("symbol")
@@ -203,8 +205,8 @@ def test_humbl_channel_historical_integration(
         )
         expected_google_top_and_bottom = (
             "GOOGL",
-            pytest.approx(40.72, rel=1e-3),
-            pytest.approx(43.00, rel=1e-3),
+            pytest.approx(40.04, rel=1e-3),
+            pytest.approx(43.72, rel=1e-3),
         )
         amd_top_and_bottom_mean = (
             mandelbrot_historical.group_by("symbol")
@@ -213,8 +215,8 @@ def test_humbl_channel_historical_integration(
         )
         expected_amd_top_and_bottom = (
             "AMD",
-            pytest.approx(23.65, rel=1e-3),
-            pytest.approx(27.26, rel=1e-3),
+            pytest.approx(23.76, rel=1e-3),
+            pytest.approx(27.08, rel=1e-3),
         )
 
         assert google_top_and_bottom_mean == expected_google_top_and_bottom
@@ -231,8 +233,8 @@ def test_humbl_channel_historical_integration(
         )
         expected_aapl_top_and_bottom = (
             "AAPL",
-            pytest.approx(33.43, rel=1e-3),
-            pytest.approx(35.75, rel=1e-3),
+            pytest.approx(33.36, rel=1e-3),
+            pytest.approx(35.68, rel=1e-3),
         )
 
         assert aapl_top_and_bottom_mean == expected_aapl_top_and_bottom


### PR DESCRIPTION
Fixes #46.

## Summary
- build historical calculation dates from each symbol's own available data window
- only include symbols that are eligible and have data on the target date
- add a regression for misaligned symbols so mixed-symbol output matches single-symbol output and contains no null channel prices

## Verification
- .venv/bin/pytest tests/integration/toolbox/technical/mandelbrot_channel/test_model.py::test_humbl_channel_historical_uses_each_symbols_own_start_date
- .venv/bin/python reproduction against tests/test_data/test_data.parquet for PCT/AAPL: zero null price rows and PCT slice matches PCT-only run
- uv run ruff format --check src/humbldata/toolbox/technical/humbl_channel/model.py tests/integration/toolbox/technical/mandelbrot_channel/test_model.py
- uv run ruff check --no-fix --select F src/humbldata/toolbox/technical/humbl_channel/model.py tests/integration/toolbox/technical/mandelbrot_channel/test_model.py

Note: full Ruff check on these files still reports existing docstring/line-length findings already present on origin/master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Humbl Channel historical calculations now respect each symbol's own available-history window, producing accurate non-null prices when symbols start on different dates.

* **Tests**
  * Added integration coverage that generates deterministic synthetic equity data and verifies historical Humbl Channel results are consistent across multi-symbol and single-symbol runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/humblFINANCE/humblDATA/pull/57)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->