### PR TITLE
test: cover OpenBB helper API calls

### DIFF
--- a/src/humbldata/core/standard_models/openbbapi/EquityPriceQuoteQueryParams.py
+++ b/src/humbldata/core/standard_models/openbbapi/EquityPriceQuoteQueryParams.py
@@ -1,4 +1,9 @@
-from typing import List, Literal, Optional, Union
+"""Query parameters for OpenBB equity price quote endpoints."""
+
+# ruff: noqa: INP001
+
+from typing import Literal
+
 from humbldata.core.standard_models.abstract.query_params import QueryParams
 
 
@@ -9,15 +14,17 @@ class EquityPriceQuoteQueryParams(QueryParams):
     Parameters
     ----------
     symbol : str | list[str]
-        Symbol(s) to get data for. Multiple comma separated items allowed for provider(s): fmp, intrinio, yfinance.
+        Symbol(s) to get data for. Multiple comma separated items allowed for
+        provider(s): fmp, intrinio, yfinance.
     provider : Literal['fmp', 'intrinio', 'yfinance'] | None, optional
-        The provider to use. If None, the default priority list is used: fmp, intrinio, yfinance.
-    source : Optional[Literal['iex', 'bats', 'bats_delayed', 'utp_delayed', 'cta_a_delayed', 'cta_b_delayed', 'intrinio_mx', 'intrinio_mx_plus', 'delayed_sip']]
+        The provider to use. If None, the default priority list is used:
+        fmp, intrinio, yfinance.
+    source
         Source of the data. Only used for provider 'intrinio'.
     """
 
     symbol: str | list[str]
-    provider: Literal["fmp", "intrinio", "yfinance"] = "yfinance"
+    provider: Literal["fmp", "intrinio", "yfinance"] | None = "yfinance"
     source: (
         Literal[
             "iex",

--- a/tests/unittests/core/test_openbb_helpers.py
+++ b/tests/unittests/core/test_openbb_helpers.py
@@ -1,35 +1,181 @@
-from unittest.mock import patch
+"""Tests for OpenBB helper API-client wrappers."""
+
+import asyncio
+from unittest.mock import AsyncMock
 
 import polars as pl
-import pytest
-from openbb_core.app.model.abstract.error import OpenBBError
 
-from humbldata.core.utils.openbb_helpers import get_latest_price, obb_login
-
-pytestmark = pytest.mark.skip(reason="Need to figure out OBB Login")
-
-# skip_if_not_logged_in = pytest.mark.skipif(
-#     not obb_login(), reason="Login failed"
-# )
-
-# Need to find a way to test making web requests without actually making them,
-# potentially mock the obb function call
+from humbldata.core.utils import openbb_helpers
 
 
-# @skip_if_not_logged_in
-# @pytest.mark.skip()
-@pytest.mark.parametrize(
-    "symbol",
-    ["AAPL", ["AAPL", "GOOGL"]],
-)
-def test_get_latest_price(symbol):
-    """Test the get_recent_price function."""
-    prices = get_latest_price(symbol, "fmp")
-    assert isinstance(prices, pl.LazyFrame)
+class MockOpenBBResponse:
+    """Minimal response object returned by the mocked OpenBB API client."""
+
+    def __init__(self, frame: pl.DataFrame | None):
+        self._frame = frame
+        self.results = None if frame is None else frame.to_dicts()
+
+    def to_polars(self, *, collect: bool = True) -> pl.LazyFrame:
+        """Return the mocked response data as a lazy frame."""
+        assert collect is False
+        if self._frame is None:
+            return pl.LazyFrame([])
+        return self._frame.lazy()
 
 
-@pytest.mark.skip()
-def test_get_latest_price_with_invalid_symbol():
-    """Test that get_recent_price raises a ValueError when an invalid symbol is passed."""
-    with pytest.raises(OpenBBError):
-        get_latest_price("")
+def patch_openbb_client(monkeypatch, response: MockOpenBBResponse) -> AsyncMock:
+    """Patch OpenBBAPIClient and return its fetch_data mock."""
+    fetch_data = AsyncMock(return_value=response)
+
+    class MockOpenBBAPIClient:
+        def __init__(self):
+            self.fetch_data = fetch_data
+
+    monkeypatch.setattr(openbb_helpers, "OpenBBAPIClient", MockOpenBBAPIClient)
+    return fetch_data
+
+
+def test_aget_latest_price_fetches_quote_data(monkeypatch):
+    """Latest price helper fetches equity quote data through the API client."""
+    response = MockOpenBBResponse(
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL", "SPY"],
+                "asset_type": ["EQUITY", "ETF"],
+                "last_price": [191.25, 562.10],
+                "prev_close": [190.75, 560.50],
+            }
+        )
+    )
+    fetch_data = patch_openbb_client(monkeypatch, response)
+
+    prices = asyncio.run(
+        openbb_helpers.aget_latest_price(
+            pl.Series("symbol", ["AAPL", "SPY"]), provider="yfinance"
+        )
+    )
+
+    assert prices.collect().to_dicts() == [
+        {"last_price": 191.25, "symbol": "AAPL"},
+        {"last_price": 560.50, "symbol": "SPY"},
+    ]
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "equity.price.quote"
+    assert kwargs["api_query_params"].symbol == ["AAPL", "SPY"]
+    assert kwargs["api_query_params"].provider == "yfinance"
+
+
+def test_aget_latest_price_ignores_unsupported_provider(monkeypatch):
+    """Unsupported quote providers are omitted from query params."""
+    response = MockOpenBBResponse(
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "last_price": [191.25],
+            }
+        )
+    )
+    fetch_data = patch_openbb_client(monkeypatch, response)
+
+    prices = asyncio.run(
+        openbb_helpers.aget_latest_price("AAPL", provider="tmx")
+    )
+
+    assert prices.collect().to_dicts() == [
+        {"symbol": "AAPL", "last_price": 191.25}
+    ]
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "equity.price.quote"
+    assert kwargs["api_query_params"].symbol == "AAPL"
+    assert kwargs["api_query_params"].provider is None
+
+
+def test_aget_equity_sector_fetches_profile_data(monkeypatch):
+    """Equity sector helper fetches profile data through the API client."""
+    response = MockOpenBBResponse(
+        pl.DataFrame(
+            {
+                "symbol": ["AAPL", "MSFT"],
+                "sector": ["Technology", "Technology"],
+                "industry": ["Consumer Electronics", "Software"],
+            }
+        )
+    )
+    fetch_data = patch_openbb_client(monkeypatch, response)
+
+    sectors = asyncio.run(
+        openbb_helpers.aget_equity_sector(["AAPL", "MSFT"], provider="fmp")
+    )
+
+    assert sectors.collect().to_dicts() == [
+        {"symbol": "AAPL", "sector": "Technology"},
+        {"symbol": "MSFT", "sector": "Technology"},
+    ]
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "equity.profile"
+    assert kwargs["api_query_params"].symbol == ["AAPL", "MSFT"]
+    assert kwargs["api_query_params"].provider == "fmp"
+
+
+def test_aget_equity_sector_returns_null_sector_when_missing(
+    monkeypatch,
+):
+    """Return null sectors when profile data omits them."""
+    response = MockOpenBBResponse(
+        pl.DataFrame(
+            {
+                "symbol": ["SPY"],
+                "name": ["SPDR S&P 500 ETF Trust"],
+            }
+        )
+    )
+    patch_openbb_client(monkeypatch, response)
+
+    sectors = asyncio.run(openbb_helpers.aget_equity_sector("SPY"))
+
+    assert sectors.collect().to_dicts() == [{"symbol": "SPY", "sector": None}]
+
+
+def test_aget_etf_category_fetches_only_known_etfs(monkeypatch):
+    """ETF category helper fetches API data only for recognized ETFs."""
+    response = MockOpenBBResponse(
+        pl.DataFrame(
+            {
+                "symbol": ["SPY"],
+                "category": ["Large Blend"],
+                "name": ["SPDR S&P 500 ETF Trust"],
+            }
+        )
+    )
+    fetch_data = patch_openbb_client(monkeypatch, response)
+
+    categories = asyncio.run(
+        openbb_helpers.aget_etf_category(["SPY", "AAPL"], provider="fmp")
+    )
+
+    assert categories.collect().to_dicts() == [
+        {"symbol": "SPY", "category": "Large Blend"},
+        {"symbol": "AAPL", "category": None},
+    ]
+    fetch_data.assert_awaited_once()
+    _, kwargs = fetch_data.call_args
+    assert kwargs["obb_path"] == "etf.info"
+    assert kwargs["api_query_params"].symbol == ["SPY"]
+    assert kwargs["api_query_params"].provider == "fmp"
+
+
+def test_aget_etf_category_skips_api_call_when_no_symbols_are_etfs(
+    monkeypatch,
+):
+    """ETF category helper avoids API calls when no symbols are known ETFs."""
+    fetch_data = patch_openbb_client(monkeypatch, MockOpenBBResponse(None))
+
+    categories = asyncio.run(openbb_helpers.aget_etf_category(["AAPL", "MSFT"]))
+
+    assert categories.collect().to_dicts() == [
+        {"symbol": "AAPL", "category": None},
+        {"symbol": "MSFT", "category": None},
+    ]
+    fetch_data.assert_not_awaited()


### PR DESCRIPTION
## Summary
- replace the stale skipped OpenBB helper tests with active mocked API-client coverage
- cover `aget_latest_price`, `aget_equity_sector`, and `aget_etf_category` without real OpenBB/API calls
- allow quote query params to omit unsupported providers, matching `aget_latest_price` fallback behavior

Closes #38
/claim #38

Note: I noticed existing PR #54 after implementation; this PR adds the same core mocked coverage plus an extra provider-normalization regression test and the small query-param schema fix it exposed.

## Verification
- `uv run --frozen pytest tests/unittests/core/test_openbb_helpers.py`
- `uv run --frozen pytest tests/test_import.py tests/test_cli.py tests/unittests/core/test_openbb_helpers.py`
- `uv run --frozen --group test ruff check tests/unittests/core/test_openbb_helpers.py src/humbldata/core/standard_models/openbbapi/EquityPriceQuoteQueryParams.py`
- `uv run --frozen --group test ruff format --check tests/unittests/core/test_openbb_helpers.py src/humbldata/core/standard_models/openbbapi/EquityPriceQuoteQueryParams.py`
- `uv run --frozen python -m py_compile tests/unittests/core/test_openbb_helpers.py src/humbldata/core/standard_models/openbbapi/EquityPriceQuoteQueryParams.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `provider` parameter for equity price queries is now optional, with "yfinance" as the default fallback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/humblFINANCE/humblDATA/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->