### PR TITLE
Add nox testing suite with Python 3.11/3.12 matrix

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,82 @@
+"""Nox sessions for humblDATA testing suite.
+
+Runs pytest across a matrix of supported Python versions with
+coverage and JUnit XML reporting for CI integration.
+"""
+
+from __future__ import annotations
+
+import nox
+
+# Supported Python versions (aligned with requires-python >=3.11,<3.13)
+PYTHON_VERSIONS = ["3.11", "3.12"]
+
+# Default locations
+PYTEST_LOCATIONS = ["src", "tests"]
+
+
+@nox.session(python=PYTHON_VERSIONS, tags=["tests"])
+def tests(session: nox.Session) -> None:
+    """Run the full test suite with coverage."""
+    session.install(".[test]")
+    session.install(
+        "coverage[toml]",
+        "pytest",
+        "pytest-asyncio",
+        "pytest-mock",
+        "pytest-xdist",
+        "pytest-clarity",
+    )
+    session.run(
+        "coverage",
+        "run",
+        "--module",
+        "pytest",
+        *PYTEST_LOCATIONS,
+        "--color=yes",
+        "--exitfirst",
+        "--failed-first",
+        "--strict-config",
+        "--strict-markers",
+        "--verbosity=2",
+        "--junitxml=reports/pytest.xml",
+    )
+    session.run("coverage", "report")
+    session.run("coverage", "xml", "-o", "reports/coverage.xml")
+
+
+@nox.session(python=PYTHON_VERSIONS[0], tags=["lint"])
+def lint(session: nox.Session) -> None:
+    """Run linting checks."""
+    session.install("ruff")
+    session.run("ruff", "check", "src", "tests")
+
+
+@nox.session(python=PYTHON_VERSIONS[0], tags=["tests"])
+def unit(session: nox.Session) -> None:
+    """Run only unit tests."""
+    session.install(".[test]")
+    session.install("pytest", "pytest-asyncio", "pytest-mock")
+    session.run(
+        "pytest",
+        "tests/unittests",
+        "--color=yes",
+        "--verbosity=2",
+        "-m",
+        "not slow",
+    )
+
+
+@nox.session(python=PYTHON_VERSIONS[0], tags=["tests"])
+def integration(session: nox.Session) -> None:
+    """Run only integration tests."""
+    session.install(".[test]")
+    session.install("pytest", "pytest-asyncio", "pytest-mock")
+    session.run(
+        "pytest",
+        "tests/integration",
+        "--color=yes",
+        "--verbosity=2",
+        "-m",
+        "not slow",
+    )


### PR DESCRIPTION
## Summary

Adds a `noxfile.py` testing suite as requested in #4.

### Changes
- **noxfile.py** with 4 sessions: tests (matrix), lint, unit, integration
- Coverage and JUnit XML reporting for CI
- Python 3.11 and 3.12 matrix aligned with `requires-python >=3.11,<3.13`

### Usage
`ash
nox              # Run all sessions
nox -s tests     # Full test suite
nox -s lint      # Ruff linting
nox -s unit      # Unit tests only
nox -s integration  # Integration tests only
``

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented comprehensive automated testing framework with coverage reporting for Python 3.11 and 3.12
  * Integrated code quality checks and linting tools to maintain development standards
  * Configured separate test execution workflows for unit and integration testing
  * Automated test runs to ensure code quality and reliability across project updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/humblFINANCE/humblDATA/pull/61)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->