### PR TITLE
ci: align branch refs to develop and main

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - release
-    tags: # only created when `bump.yml` is run, which only runs on master push!
+    tags: # only created when `bump.yml` is run, which only runs on main push!
       - "v*"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,8 @@ name: Run Python tests
 on:
   push:
     branches:
-      - main
-      - master
       - develop
+      - main
   pull_request:
 
 jobs:
@@ -33,7 +32,7 @@ jobs:
       # Non-blocking for now: this workflow previously used Poetry against a
       # pyproject.toml that has used uv/hatchling for a long time (no
       # poetry.lock has existed in this repo - see AGENTS.md), and only ran
-      # on push to main/master, never on pull_request. In practice that
+      # on push to develop/main, never on pull_request. In practice that
       # means this test suite has not gated any change in a long time, and
       # ~70 pre-existing failures/errors (numeric assertions, stale
       # doctests, fixtures) accumulated silently. Fixing all of it is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ Environment variables load from a root `.env` (no `.env.example` is committed - 
 
 There is no manual "deploy" step - releases and docs publish automatically from CI:
 
-1. Push commits to `main`/`master` (gitmoji conventional commits, see below) -> `.github/workflows/test.yml` runs Poetry-based pytest.
-2. `.github/workflows/bump.yml` runs Commitizen, bumps `version` in `pyproject.toml`, updates `CHANGELOG.md`, tags `v$version`, and creates a GitHub release. Skips if the triggering commit message already contains `bump(release)`.
+1. Push commits to `develop` (integration) or `main` (release; gitmoji conventional commits, see below) -> `.github/workflows/test.yml` runs pytest on push to both branches.
+2. `.github/workflows/bump.yml` runs Commitizen on push to `main` only, bumps `version` in `pyproject.toml`, updates `CHANGELOG.md`, tags `v$version`, and creates a GitHub release. Skips if the triggering commit message already contains `bump(release)`.
 3. That tag push triggers, in parallel:
    - `.github/workflows/publish.yml` - `uv build` + `uv publish` to PyPI (`POETRY_PYPI_TOKEN_PYPI` secret). Also triggers on push to a `release` branch.
    - `.github/workflows/docs.yml` - `uv run mkdocs gh-deploy --force` to GitHub Pages.

--- a/docs/getting_started/development_setup.md
+++ b/docs/getting_started/development_setup.md
@@ -211,7 +211,7 @@ There are __4__ pre-made github actions that are used with this package. Some ac
         - `POETRY_HTTP_BASIC__PASSWORD`: This is a secret used for authentication with the private package repository.
         - `POETRY_PYPI_TOKEN_PYPI`: This is a secret used for authentication with PyPi, if the package is being published there.
 ??? abstract "4. `test.yml`"
-    This workflow is responsible for testing the project. It is triggered on push events to the main and master branches, and on pull requests.
+    This workflow is responsible for testing the project. It is triggered on push events to the `develop` and `main` branches, and on pull requests.
 
     The workflow runs on an Ubuntu-latest environment and uses the specified Python version.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: "https://humblfinance.github.io/humbldata/"
 repo_name: humbldata
 site_dir: "site"
 copyright: Copyright &copy; 2024 Jennings Fantini
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/
 site_author: Jennings Fantini
 
 watch:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drop master branch refs from CI workflows and docs. test.yml triggers on develop + main; bump.yml on main only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48cabceb-e754-4406-b5de-8670a8fc6ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48cabceb-e754-4406-b5de-8670a8fc6ebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

