### PR TITLE
docs: add Cursor Cloud environment setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,12 @@ Gitmoji conventional commits (`.cz-config.js` / `.pre-commit-config.yaml` runs `
 - `poetry.lock` does not exist; `uv.lock` is canonical, but `test.yml` CI and pre-commit's `poetry-check` still assume Poetry.
 - `.devcontainer/` and a `Dockerfile` are referenced in docs but not present in the repo.
 - `src/humbldata/cli.py` exists but has no `[project.scripts]` entry point - it is not installed as a CLI.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `uv sync --all-groups` here, so deps are installed. Notes:
+
+- **`.env` is required but not committed.** A minimal dev `.env` at the repo root is enough: `ENVIRONMENT=development`, `OPENBB_API_DEV_URL`/`OPENBB_API_PROD_URL=https://data.humblfinance.io`, `OPENBB_API_PREFIX=/api/v1`, `REDIS_URL=redis://localhost:6379`. All `Env` properties have safe defaults, so `import humbldata` works without it, but integration/data paths call the hosted OpenBB API (`data.humblfinance.io`) and need network.
+- **Use `--all-groups`, not plain `uv sync`.** The test/lint tooling (pytest-asyncio, ruff, mypy, pre-commit, safety) lives in non-default dependency groups; plain `uv sync` omits them and pytest then fails collection with `'asyncio' not found in markers` under `--strict-markers`.
+- **The test suite has ~70 pre-existing failures that CI tolerates** (`test.yml` marks `poe test` `continue-on-error: true`). Notably: some files do `from src.humbldata...` (breaks under `--import-mode=importlib`), and several assertions/doctests are stale (e.g. plotly `heatmapgl` deprecation). Don't assume a red suite is your fault - run a targeted subset (e.g. `uv run pytest tests/test_import.py`) to sanity-check the harness.
+- Lint tooling runs via `uv run ruff check ...` and `uv run mypy ...`; `poe lint` also runs `pre-commit` (downloads hook envs on first run) and `safety`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious dev-environment caveats discovered while setting up and running this library in a Cursor Cloud VM.

Documented caveats:
- A root `.env` is required-but-not-committed (safe dev defaults; OpenBB defaults to hosted `data.humblfinance.io` and needs network).
- Use `uv sync --all-groups` (not plain `uv sync`) so test/lint tooling (pytest-asyncio, ruff, mypy) is installed - otherwise pytest fails collection with `'asyncio' not found in markers` under `--strict-markers`.
- The test suite has ~70 pre-existing failures that CI tolerates (`continue-on-error`); some files use broken `from src.humbldata` imports and stale assertions/doctests. Run a targeted subset to sanity-check the harness.

No code changes.

## Verification
- `uv sync --all-groups` installs cleanly.
- `uv run python -c "import humbldata"` succeeds.
- `uv run pytest tests/test_import.py` passes.
- `uv run ruff --version` / `uv run mypy --version` available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30946d57-44da-4243-9cbf-7c9d297a66c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30946d57-44da-4243-9cbf-7c9d297a66c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

